### PR TITLE
Adds hint for jQuery-specific selectors

### DIFF
--- a/transforms/acceptance/__testfixtures__/warning-jquery-selector.input.js
+++ b/transforms/acceptance/__testfixtures__/warning-jquery-selector.input.js
@@ -1,0 +1,21 @@
+import { setupApplicationTest } from 'ember-qunit';
+import { find, click } from '@ember/test-helpers';
+
+module('some module', function(hooks) {
+  setupApplicationTest(hooks);
+
+  let selectors = {
+    regularSelector: '.another-class',
+    someSelector: '.some-class:contains("Text")',
+    title: 'tr:first-child td:first-child a span',
+    heading: 'tr:last-child',
+  };
+
+  test('jquery selector', async function(assert) {
+    let $someEl = find('.specific-item:eq(4)');
+    let $otherEl = find(`${selectors.regularSelector}:last`);
+    click(':visible');
+    click(find('.specific-item:first'));
+    click(selectors.regularSelector);
+  });
+});

--- a/transforms/acceptance/__testfixtures__/warning-jquery-selector.output.js
+++ b/transforms/acceptance/__testfixtures__/warning-jquery-selector.output.js
@@ -1,0 +1,26 @@
+import { setupApplicationTest } from 'ember-qunit';
+import { find, click } from '@ember/test-helpers';
+
+module('some module', function(hooks) {
+  setupApplicationTest(hooks);
+
+  let selectors = {
+    regularSelector: '.another-class',
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    someSelector: '.some-class:contains("Text")',
+    title: 'tr:first-child td:first-child a span',
+    heading: 'tr:last-child',
+  };
+
+  test('jquery selector', async function(assert) {
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    let $someEl = find('.specific-item:eq(4)');
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    let $otherEl = find(`${selectors.regularSelector}:last`);
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    click(':visible');
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    click(find('.specific-item:first'));
+    click(selectors.regularSelector);
+  });
+});

--- a/transforms/acceptance/index.js
+++ b/transforms/acceptance/index.js
@@ -7,6 +7,7 @@ const { trackingPageEventMigration } = require('./tracking_page_event_migration'
 const { setupFactoryGuy } = require('../../utils/factoryguy');
 const { removeEmptyBlock } = require('../../utils/general');
 const { find, findWithAssert } = require('../../utils/acceptance/find');
+const { warnjQuerySelector } = require('../../utils/warn-jquery-selector');
 const { replaceConst } = require('../../utils/const');
 const {
   transformAssertCurrentRoute,
@@ -125,6 +126,8 @@ module.exports = function transformer(file, api) {
   // general
   code = removeEmptyBlock(j, code);
   code = replaceConst(j, code, 'SELECTORS');
-
+  
+  code = warnjQuerySelector(j, code);
+  
   return code;
 };

--- a/transforms/component-integration-test/__testfixtures__/warning-jquery-selector.input.js
+++ b/transforms/component-integration-test/__testfixtures__/warning-jquery-selector.input.js
@@ -1,0 +1,22 @@
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { find, click, render } from '@ember/test-helpers';
+
+module('some module', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let selectors = {
+    regularSelector: '.another-class',
+    someSelector: '.some-class:contains("Text")',
+    title: 'tr:first-child td:first-child a span',
+    heading: 'tr:last-child',
+  };
+
+  test('jquery selector', async function(assert) {
+    let $someEl = find('.specific-item:eq(4)');
+    let $otherEl = find(`${selectors.regularSelector}:last`);
+    click(':visible');
+    click(find('.specific-item:first'));
+    click(selectors.regularSelector);
+  });
+});

--- a/transforms/component-integration-test/__testfixtures__/warning-jquery-selector.output.js
+++ b/transforms/component-integration-test/__testfixtures__/warning-jquery-selector.output.js
@@ -1,0 +1,27 @@
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { find, click, render } from '@ember/test-helpers';
+
+module('some module', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let selectors = {
+    regularSelector: '.another-class',
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    someSelector: '.some-class:contains("Text")',
+    title: 'tr:first-child td:first-child a span',
+    heading: 'tr:last-child',
+  };
+
+  test('jquery selector', async function(assert) {
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    let $someEl = find('.specific-item:eq(4)');
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    let $otherEl = find(`${selectors.regularSelector}:last`);
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    click(':visible');
+    //TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead
+    click(find('.specific-item:first'));
+    click(selectors.regularSelector);
+  });
+});

--- a/transforms/component-integration-test/index.js
+++ b/transforms/component-integration-test/index.js
@@ -15,6 +15,7 @@ const { getNotificationServiceFunctions } = require('../../utils/notifications')
 const { removeEmptyBlock } = require('../../utils/general');
 const { getRenderingCollection, replaceSurroundingContext } = require('../../utils/rendering');
 const { setupFactoryGuy } = require('../../utils/factoryguy');
+const { warnjQuerySelector } = require('../../utils/warn-jquery-selector');
 
 module.exports = function transformer(file, api) {
   const j = getParser(api);
@@ -289,6 +290,9 @@ module.exports = function transformer(file, api) {
       })
       .toSource();
   }
+
+  //hints
+  code = warnjQuerySelector(j, code);
 
   // general
   code = removeEmptyBlock(j, code);

--- a/utils/warn-jquery-selector.js
+++ b/utils/warn-jquery-selector.js
@@ -1,0 +1,42 @@
+const SELECTORS_REGEX = /:(first(\s|$)|last(\s|$)|(eq|nth)\(|(lt|gt)\(|(even|odd)|contains\(|visible|header|parent|selected|input|button|checkbox|file|image|password|radio|reset|submit|text|is\()/;
+
+function closestAncestorOfType(path, typeRegex) {
+  let current = path.parentPath;
+  while (current.parentPath && !typeRegex.test(current.value.type)) {
+    current = current.parentPath;
+  }
+  return current || null;
+}
+
+function processLiteral(path, comment) {
+  let ancestor = closestAncestorOfType(path, /ExpressionStatement|VariableDeclaration|Property/);
+  const comments = (ancestor.node.comments = ancestor.node.comments || []);
+  let hasHint = comments.find(c => c.value.includes('Refactor jQuery-specific selectors'));
+  if (!hasHint) {
+    comments.push(comment);
+  }
+}
+
+function warnjQuerySelector(j, code) {
+  const comment = j.commentLine(
+    'TEST MIGRATION HINT: Refactor jQuery-specific selectors, e.g. `:first`, `:contains()`, `:eq()`, as these are not valid when using helpers from `@ember/test-helpers`. Query the element differently or use an ember-test-selector instead',
+    true,
+    false,
+  );
+  code = j(code)
+    .find(j.Literal, path => {
+      return SELECTORS_REGEX.test(path.value);
+    })
+    .forEach(path => processLiteral(path, comment))
+    .toSource();
+  return j(code)
+    .find(j.TemplateElement, path => {
+      return SELECTORS_REGEX.test(path.value.raw);
+    })
+    .forEach(path => processLiteral(path, comment))
+    .toSource();
+}
+
+module.exports = {
+  warnjQuerySelector,
+};


### PR DESCRIPTION
Part of https://github.com/intercom/intercom/issues/106087 and https://github.com/intercom/intercom/issues/122717

Adds a hint to acceptance and integration codemods for others migrating tests to help with ambiguous cases where we can't automatically use a codemod.

* Adds a hint for jQuery specific selectors such as those that use `:contains`, `:first`, `:last`, `:eq()` etc.

![image](https://user-images.githubusercontent.com/685034/49280856-0f563080-f483-11e8-8011-b04454955d57.png)

These codemods shouldn't be merged before this [ESLint rule](https://github.com/patocallaghan/legacy-tests-codemod/pull/25) is shipped to Embercom