### PR TITLE
Code import and run improvements

### DIFF
--- a/transforms/component-integration-test/__testfixtures__/runfunctions.input.js
+++ b/transforms/component-integration-test/__testfixtures__/runfunctions.input.js
@@ -1,0 +1,19 @@
+import { setupRenderingTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('some module', function(hooks) {
+  setupRenderingTest(hooks);
+
+  async function renderComponent(surroundingContext, options) {
+    run(() => {
+      surroundingContext.setProperties(options);
+      return render(TEMPLATE);
+    });
+  }
+
+  test('my test name', async function() {
+    run(() => {
+      renderComponent(this);
+    });
+  });
+});

--- a/transforms/component-integration-test/__testfixtures__/runfunctions.output.js
+++ b/transforms/component-integration-test/__testfixtures__/runfunctions.output.js
@@ -1,0 +1,17 @@
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from "qunit";
+import { render } from "@ember/test-helpers";
+import { run } from '@ember/runloop';
+
+module('some module', function(hooks) {
+  setupRenderingTest(hooks);
+
+  function renderComponent(surroundingContext, options) {
+    surroundingContext.setProperties(options);
+    return render(template);
+  }
+
+  test('my test name', async function() {
+    await renderComponent(this);
+  });
+});

--- a/transforms/component-integration-test/__testfixtures__/singleimport.input.js
+++ b/transforms/component-integration-test/__testfixtures__/singleimport.input.js
@@ -1,0 +1,6 @@
+import { make, makeList } from 'ember-data-factory-guy';
+import { mockFindAll } from 'ember-data-factory-guy';
+
+module('Team Inbox | Component | inbox/inbox-component', function(hooks) {
+  setupTest(hooks);
+});

--- a/transforms/component-integration-test/__testfixtures__/singleimport.output.js
+++ b/transforms/component-integration-test/__testfixtures__/singleimport.output.js
@@ -1,0 +1,10 @@
+import { make, makeList, setupFactoryGuy } from 'ember-data-factory-guy';
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import { mockFindAll } from 'ember-data-factory-guy';
+
+module('Team Inbox | Component | inbox/inbox-component', function(hooks) {
+  setupRenderingTest(hooks);
+  setupFactoryGuy(hooks);
+});

--- a/transforms/component-integration-test/index.js
+++ b/transforms/component-integration-test/index.js
@@ -12,8 +12,12 @@ const {
   replaceContextualFunctionWithExplicitlyImportedFunction,
 } = require('../../utils/function');
 const { getNotificationServiceFunctions } = require('../../utils/notifications');
-const { removeEmptyBlock } = require('../../utils/general');
-const { getRenderingCollection, replaceSurroundingContext } = require('../../utils/rendering');
+const { removeEmptyBlock, findRunFunctions } = require('../../utils/general');
+const {
+  removeRenderWrapping,
+  getRenderingCollection,
+  replaceSurroundingContext,
+} = require('../../utils/rendering');
 const { setupFactoryGuy } = require('../../utils/factoryguy');
 const { warnjQuerySelector } = require('../../utils/warn-jquery-selector');
 
@@ -21,6 +25,10 @@ module.exports = function transformer(file, api) {
   const j = getParser(api);
 
   let code = file.source;
+
+  // cleanup run functions
+  let runFunctions = findRunFunctions(j, code);
+  code = removeRenderWrapping(j, code, runFunctions);
 
   // remove unused imports
   code = removeImport(j, code, 'embercom/tests/helpers/legacy/component-integration-testing');

--- a/utils/general.js
+++ b/utils/general.js
@@ -20,6 +20,18 @@ function removeEmptyBlock(j, code) {
     .toSource();
 }
 
+function findRunFunctions(j, code) {
+  return j(code).find(j.ExpressionStatement, {
+    expression: {
+      type: 'CallExpression',
+      callee: {
+        name: 'run',
+      },
+    },
+  });
+}
+
 module.exports = {
   removeEmptyBlock,
+  findRunFunctions,
 };

--- a/utils/imports.js
+++ b/utils/imports.js
@@ -2,6 +2,7 @@ function addImport(j, code, importName, sourceName) {
   let hasImport = false;
   code = j(code)
     .find(j.ImportDeclaration, { source: { value: sourceName } })
+    .at(0)
     .forEach(statement => {
       if (statement.value.source.value === sourceName) {
         let existingImports = statement.value.specifiers.map(s => s.imported.name);
@@ -64,6 +65,20 @@ function replaceImportedFunction(j, code, name, newName, newSource) {
   }
   return code;
 }
+
+// let importLocations = {};
+// code = j(code)
+//   .find(j.ImportDeclaration)
+//   .forEach(path => {
+//     let specifiers = path.value.specifiers.map(spec => spec.local.name);
+//     if (importLocations[path.value.source.value] === undefined) {
+//       importLocations[path.value.source.value] = specifiers;
+//     } else {
+//       importLocations[path.value.source.value].push(...specifiers);
+//     }
+//     j(path).remove();
+//   })
+//   .toSource();
 
 module.exports = {
   addImport,

--- a/utils/rendering.js
+++ b/utils/rendering.js
@@ -1,3 +1,26 @@
+function removeRenderWrapping(j, code, runFunctions) {
+  return runFunctions
+    .forEach(path => {
+      let runMethods = path.value.expression.arguments[0].body.body;
+      if (runMethods === undefined) {
+        return;
+      }
+      let rendersComponent = runMethods.some(method => {
+        if (method.type != 'ExpressionStatement') {
+          return false;
+        }
+
+        if (method.expression.callee.type === 'MemberExpression') {
+          return method.expression.callee.property.name.includes('render');
+        } else {
+          return method.expression.callee.name.includes('render');
+        }
+      });
+      j(path).replaceWith(runMethods);
+    })
+    .toSource();
+}
+
 function getRenderingCollection(j, code) {
   return j(code).find(j.ExpressionStatement, {
     expression: {
@@ -40,6 +63,7 @@ function replaceSurroundingContext(j, code) {
 }
 
 module.exports = {
+  removeRenderWrapping,
   getRenderingCollection,
   replaceSurroundingContext,
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6685876/49742068-aa26ea00-fc8f-11e8-8c04-37f907f535d2.png)

- Remove `run` wrapping from test rendering
- Only add import specifier to the first import declaration to avoid duplicate imports